### PR TITLE
docs: add missing requirement to setup-python

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,11 @@ The workflow, usually declared in `.github/workflows/build.yml`, looks like:
         - name: Check-out the repo under $GITHUB_WORKSPACE
           uses: actions/checkout@v3
 
+        - name: Setup Python 3.8
+          uses: actions/setup-python@v3
+          with:
+            python-version: 3.8
+
         - name: Run Commisery
           uses: KevinDeJong-TomTom/commisery-action@master
           with:
@@ -35,7 +40,7 @@ The workflow, usually declared in `.github/workflows/build.yml`, looks like:
 ## Inputs
 
 - **token**: GitHub Token provided by GitHub, see [Authenticating with the GITHUB_TOKEN]
-- **pull_request**: Pull Request number, provided by the [GitHub contex].
+- **pull_request**: Pull Request number, provided by the [GitHub context].
 
 [Authenticating with the GITHUB_TOKEN]: https://help.github.com/en/actions/automating-your-workflow-with-github-actions/authenticating-with-the-github_token
 [GitHub context]: https://docs.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#github-context


### PR DESCRIPTION
### Description
Updates the README.md to clarify the added need for setting up Python v3.8 using `actions/setup-python`.

### Issues Resolved
Addresses #14 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
